### PR TITLE
Force use of TLSv1

### DIFF
--- a/lib/rendezvous.rb
+++ b/lib/rendezvous.rb
@@ -89,6 +89,7 @@ class Rendezvous
       host, port, secret = uri.host, uri.port, uri.path[1..-1]
 
       ssl_context = OpenSSL::SSL::SSLContext.new
+      ssl_context.ssl_version = :TLSv1
 
       if @ssl_verify_peer
         ssl_context.ca_file = File.expand_path("../../data/cacert.pem", __FILE__)


### PR DESCRIPTION
The upstream server was updated 10 days ago to force TLSv1 connections, which resulted in `Rendezvous::Errors::Authentication` errors because the client wasn't updated to use TLSv1 as well.
