### PR TITLE
Support TLS range, including TLS1.2

### DIFF
--- a/lib/rendezvous.rb
+++ b/lib/rendezvous.rb
@@ -89,7 +89,13 @@ class Rendezvous
       host, port, secret = uri.host, uri.port, uri.path[1..-1]
 
       ssl_context = OpenSSL::SSL::SSLContext.new
-      ssl_context.ssl_version = :TLSv1
+
+      if ssl_context.respond_to?(:min_version=)
+        ssl_context.min_version = :TLS1
+        ssl_context.max_version = :TLS1_2
+      else
+        ssl_context.ssl_version = :TLSv1
+      end
 
       if @ssl_verify_peer
         ssl_context.ca_file = File.expand_path("../../data/cacert.pem", __FILE__)


### PR DESCRIPTION
Newer Ruby/OpenSSL versions (>= 2.1, ships with Ruby >= 2.5) support specifying a version range via `min_version` and `max_version`. This will allow clients to connect to hosts that aren't supporting TLSv1.0 and TLSv1.1 (both of which are deprecated).